### PR TITLE
Cacher component sketch

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -193,4 +193,5 @@ library
     tagsoup       < 0.15,
     text          < 2.2,
     transformers  < 0.7,
-    stm >= 2.4 && < 2.6
+    stm >= 2.4 && < 2.6,
+    time

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -146,11 +146,11 @@ initialize Component {..} getView parentId = do
                   let diff = abs $ diffUTCTime now last
                   -- update no faster than once per second
                   if (diff > 1) then do
-                    FFI.consoleLog $ "cacher: waiting for new model with old model=" <> ms (logModel oldModel) -- TODO: this thread keeps running even after cacher component is unmounted?
+                    FFI.consoleLog $ "cacher: waiting for new model" -- TODO: this thread keeps running even after cacher component is unmounted?
                     -- wait for updated model from parent
                     newModel <- liftIO . atomically . takeTMVar $ parentModel -- TODO: this is not going to work with multiple cachers on the same component
                     -- let the cached component decide wheter to refresh the view
-                    FFI.consoleLog ("cacher: got new model: " <> ms (logModel newModel))
+                    FFI.consoleLog "cacher: got new model"
                     case cacherNeedsRefresh oldModel newModel of 
                      True -> do
                       drawView newModel


### PR DESCRIPTION
This allows to cache parts of view tree of a component.

```haskell
view :: Model -> View Action
view model = div_ [] [cacher model subView needsRender]

subView :: Model -> View Action
subView model = -- takes long time to compute
needsRender oldModel newModel = True 
```

the cacher component is implemented such that all actions on the subview are automatically sunk in the parent component and parent component shares it's current model with the cacher via TMVar (for now). Cacher decides when to recompute the subView - in this sketch it recomputes no more than once a second if the parent model has been changed. 

Works but throws exceptions which I assume have to do with incorrect umounting...
